### PR TITLE
Update nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
     minitest (5.8.2)
     multi_json (1.11.2)
     netrc (0.11.0)
-    nokogiri (1.6.6.2)
+    nokogiri (1.6.6.3)
       mini_portile (~> 0.6.0)
     pg (0.18.4)
     poltergeist (1.8.0)
@@ -215,7 +215,7 @@ GEM
     slop (3.6.0)
     spoon (0.0.4)
       ffi
-    spring (1.4.1)
+    spring (1.4.3)
     sprockets (3.4.0)
       rack (> 1, < 3)
     sprockets-rails (2.3.3)

--- a/wercker.yml
+++ b/wercker.yml
@@ -5,6 +5,9 @@ services:
         POSTGRES_PASSWORD: $POSTGRES_PASSWORD
 build:
     steps:
+        - script:
+            name: bundle config
+            code: bundle config build.nokogiri --use-system-libraries
         - bundle-install:
             jobs: 2
         - script:


### PR DESCRIPTION
execute bundle config build.nokogiri --use-system-libraries, before
bundle install.

When upgrading from nokogiri 1.6.6.2 to 1.6.6.3, we were failing with errors like
this:

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory:
    /pipeline/cache/bundle-install/ruby/2.2.0/gems/nokogiri-1.6.6.3/ext/nokogiri
    /usr/local/bin/ruby -r ./siteconf20151117-17-kx1dnr.rb extconf.rb
    checking if the C compiler accepts ... yes
    Building nokogiri using packaged libraries.
    checking for gzdopen() in -lz... yes
    checking for iconv... yes
...

Team Nokogiri will keep on doing their best to provide security
updates in a timely manner, but if this is a concern for you and want
to use the system library instead; abort this installation process and
reinstall nokogiri as follows:

    gem install nokogiri -- --use-system-libraries
        [--with-xml2-config=/path/to/xml2-config]
        [--with-xslt-config=/path/to/xslt-config]
```
